### PR TITLE
Fix/activity pass intents

### DIFF
--- a/android/activity/src/main/java/com/jrmitchell/cube/investigation/jitpack/modular/test/android/activity/DefaultActivityDisplayTarget.kt
+++ b/android/activity/src/main/java/com/jrmitchell/cube/investigation/jitpack/modular/test/android/activity/DefaultActivityDisplayTarget.kt
@@ -20,13 +20,13 @@ abstract class DefaultActivityDisplayTarget <L : AndroidImageLoader> : AppCompat
 	}
 	
 	override val actionResolver = MultiActionResolver().apply {
-		resolvers.add(activityIntentActionResolver("""screen.+""".toRegex()) { actionId ->
-			Intent(this@DefaultActivityDisplayTarget, this@DefaultActivityDisplayTarget::class.java).also {
-				it.putExtra(ACTION_ID_EXTRA_KEY, actionId)
-			}
-		})
+		resolvers.add(activityIntentActionResolver("""screen.+""".toRegex(), this@DefaultActivityDisplayTarget::screenIntentGenerator))
 		resolvers.add(MatchActionResolver("""back""".toRegex()) { _, _ -> finish() })
 		resolvers.add(MatchActionResolver("""close""".toRegex()) { _, _ -> finishAffinity() })
+	}
+	
+	open fun screenIntentGenerator(actionId : String) = Intent(this, this::class.java).also {
+		it.putExtra(ACTION_ID_EXTRA_KEY, actionId)
 	}
 	
 	override fun displayData(data: DisplayData) {

--- a/demoapp/src/main/java/com/jrmitchell/cube/investigation/jitpack/modular/test/demoapp/ActivityActivity.kt
+++ b/demoapp/src/main/java/com/jrmitchell/cube/investigation/jitpack/modular/test/demoapp/ActivityActivity.kt
@@ -1,6 +1,5 @@
 package com.jrmitchell.cube.investigation.jitpack.modular.test.demoapp
 
-import android.content.Intent
 import android.os.Bundle
 import android.view.View
 import android.widget.ImageView
@@ -21,7 +20,7 @@ class ActivityActivity : DefaultActivityDisplayTarget<PicassoImageLoader>() {
 	override val loadingUi: View get() = binding.loading
 	override val titleView: TextView get() = binding.display.findViewById(R.id.display_title)
 	
-	lateinit var populator : DisplayPopulator
+	lateinit var populator: DisplayPopulator
 	
 	override fun onCreate(savedInstanceState: Bundle?) {
 		super.onCreate(savedInstanceState)
@@ -35,10 +34,8 @@ class ActivityActivity : DefaultActivityDisplayTarget<PicassoImageLoader>() {
 		populator.populateDisplayFromUri(getActionId() ?: "screen0", this, this)
 	}
 	
-	override fun screenIntentGenerator(actionId: String): Intent {
-		return super.screenIntentGenerator(actionId).apply {
-			putExtra(PopulatorType::class.simpleName, intent.getStringExtra(PopulatorType::class.simpleName))
-		}
+	override fun screenIntentGenerator(actionId: String) = super.screenIntentGenerator(actionId).apply {
+		putExtra(PopulatorType::class.simpleName, intent.getStringExtra(PopulatorType::class.simpleName))
 	}
 	
 }

--- a/demoapp/src/main/java/com/jrmitchell/cube/investigation/jitpack/modular/test/demoapp/ActivityActivity.kt
+++ b/demoapp/src/main/java/com/jrmitchell/cube/investigation/jitpack/modular/test/demoapp/ActivityActivity.kt
@@ -1,5 +1,6 @@
 package com.jrmitchell.cube.investigation.jitpack.modular.test.demoapp
 
+import android.content.Intent
 import android.os.Bundle
 import android.view.View
 import android.widget.ImageView
@@ -32,6 +33,12 @@ class ActivityActivity : DefaultActivityDisplayTarget<PicassoImageLoader>() {
 		initialiseAdapter()
 		
 		populator.populateDisplayFromUri(getActionId() ?: "screen0", this, this)
+	}
+	
+	override fun screenIntentGenerator(actionId: String): Intent {
+		return super.screenIntentGenerator(actionId).apply {
+			putExtra(PopulatorType::class.simpleName, intent.getStringExtra(PopulatorType::class.simpleName))
+		}
 	}
 	
 }


### PR DESCRIPTION
### What?

- Update `DefaultActivityDisplayTarget` with `screenIntentGenerator()` `open fun`
- Override this in `ActivityActivity` to pass on the `PopulatorType` extra

### Why?

Previously, any extras passed to the first `DefaultActivityDisplayTarget` instance were not passed to any further instances created, causing these in the demo app to revert to the hardcoded placeholder populator.

This change allows implementations to have more flexibility in the way they pass data to new screens.